### PR TITLE
chore: add database seeding workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+DATABASE_URL="postgresql://neondb_owner:npg_ZMgvT4APVa9C@ep-icy-fire-adel044n-pooler.c-2.us-east-1.aws.neon.tech/nafila3?sslmode=require&channel_binding=require"
+NEXTAUTH_SECRET="set-a-strong-secret"
+NEXTAUTH_URL="http://localhost:3000"
+GOOGLE_CLIENT_ID="your-google-client-id"
+GOOGLE_CLIENT_SECRET="your-google-client-secret"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Dependencies
+/node_modules
+
+# Production
+/.next
+/out
+
+# Environment
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Editor
+.vscode
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,60 @@
-# Nafila2
-Nafila2
+# Nafila Shop Platform
+
+A responsive Next.js application template for Nafila Shop that connects entrepreneurs and investors with trust and community at the core.
+
+## Getting Started
+
+1. Install dependencies
+
+```bash
+npm install
+```
+
+2. Configure environment variables. Duplicate `.env.example` and rename to `.env.local`, then update values.
+
+```bash
+cp .env.example .env.local
+```
+
+3. Seed the database with sample data (optional but recommended)
+
+```bash
+npm run seed
+```
+
+4. Run the development server
+
+```bash
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) to view the app.
+
+## Environment Variables
+
+```
+DATABASE_URL=postgresql://neondb_owner:npg_ZMgvT4APVa9C@ep-icy-fire-adel044n-pooler.c-2.us-east-1.aws.neon.tech/nafila3?sslmode=require&channel_binding=require
+```
+
+## Features
+
+- Role-based dashboards for entrepreneurs, investors, and admins.
+- Structured idea submission canvas covering problem, solution, market, traction, and financials.
+- Investor filter controls and watchlist summaries.
+- Verification centre for KYC and business document tracking.
+- Community feed with likes and comments and sample engagement metrics.
+- Tailwind CSS design system with reusable cards, tables, and forms.
+
+## Data & Integrations
+
+- Sample users, investors, and ideas are stored in `src/lib/sampleData.ts`.
+- Run `npm run seed` to push the sample data (including user passwords) into Neon Postgres.
+- Server actions in `app/actions.ts` ready to connect with Neon Postgres.
+- Authentication UI stubbed for email/password and Google sign-in via NextAuth.
+
+## Next Steps
+
+- Wire up database reads/writes by replacing the mock data with Neon-backed queries.
+- Configure NextAuth providers for credentials and Google OAuth.
+- Implement CRUD APIs, messaging, and notifications as needed.
+- Connect identity verification providers for automated KYC checks.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ Open [http://localhost:3000](http://localhost:3000) to view the app.
 ```
 DATABASE_URL=postgresql://neondb_owner:npg_ZMgvT4APVa9C@ep-icy-fire-adel044n-pooler.c-2.us-east-1.aws.neon.tech/nafila3?sslmode=require&channel_binding=require
 ```
+Sample seeded accounts
+
+Amina Yusuf – entrepreneur (email amina@nafila.africa, password Nafila@2024)
+
+Kwame Mensah – investor (email kwame.mensah@panthera.vc, password InvestSmart!2024)
+
+Nafila Admin – administrator (email admin@nafila.africa, password AdminSecure#2024)
 
 ## Features
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,10 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    serverActions: {
+      bodySizeLimit: '2mb'
+    }
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "nafila-shop",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "seed": "ts-node --esm scripts/seed.ts"
+  },
+  "dependencies": {
+    "@neondatabase/serverless": "^0.9.0",
+    "clsx": "^2.1.0",
+    "date-fns": "^3.6.0",
+    "lucide-react": "^0.453.0",
+    "next": "^14.2.5",
+    "next-auth": "^4.24.6",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "dotenv": "^16.4.5",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.10",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "autoprefixer": "^10.4.19",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.5",
+    "postcss": "^8.4.39",
+    "tailwindcss": "^3.4.7",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.5.3"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "seed": "ts-node --esm scripts/seed.ts"
+    "seed": "tsx scripts/seed.ts"
   },
   "dependencies": {
     "@neondatabase/serverless": "^0.9.0",
@@ -31,6 +31,7 @@
     "postcss": "^8.4.39",
     "tailwindcss": "^3.4.7",
     "ts-node": "^10.9.2",
+    "tsx": "^4.16.5",
     "typescript": "^5.5.3"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -79,6 +79,9 @@ async function main() {
     comments integer default 0
   )`;
 
+  const toJsonb = (value: unknown) =>
+    value === undefined || value === null ? null : JSON.stringify(value);
+
   for (const user of users) {
     await sql`
       insert into users (
@@ -93,9 +96,9 @@ async function main() {
         ${user.avatarUrl ?? null},
         ${user.bio ?? null},
         ${user.location ?? null},
-        ${user.socialHandles ? sql.json(user.socialHandles) : null},
-        ${user.verification ? sql.json(user.verification) : null},
-        ${user.metrics ? sql.json(user.metrics) : null}
+        ${toJsonb(user.socialHandles)},
+        ${toJsonb(user.verification)},
+        ${toJsonb(user.metrics)}
       )
       on conflict (id) do update set
         name = excluded.name,
@@ -129,7 +132,7 @@ async function main() {
         ${idea.financialProjections},
         ${idea.traction},
         ${idea.location},
-        ${idea.media ? sql.json(idea.media) : null},
+        ${toJsonb(idea.media)},
         ${idea.status},
         ${idea.targetRaise ?? null},
         ${idea.followers},

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -3,7 +3,7 @@ import {
   primaryInvestors,
   socialFeed,
   users,
-} from "../src/lib/sampleData";
+} from "../src/lib/sampleData.ts";
 
 import { config as loadEnv } from "dotenv";
 import { neon } from "@neondatabase/serverless";

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,0 +1,210 @@
+import {
+  primaryEntrepreneurIdeas,
+  primaryInvestors,
+  socialFeed,
+  users,
+} from "../src/lib/sampleData";
+
+import { config as loadEnv } from "dotenv";
+import { neon } from "@neondatabase/serverless";
+
+loadEnv();
+loadEnv({ path: ".env.local", override: true });
+
+async function main() {
+  const connectionString = process.env.DATABASE_URL;
+
+  if (!connectionString) {
+    throw new Error(
+      "DATABASE_URL is not defined. Please set it in your environment before seeding."
+    );
+  }
+
+  const sql = neon(connectionString);
+
+  await sql`create table if not exists users (
+    id text primary key,
+    name text not null,
+    email text unique not null,
+    role text not null,
+    password text not null,
+    avatar_url text,
+    bio text,
+    location text,
+    social_handles jsonb,
+    verification jsonb,
+    metrics jsonb,
+    created_at timestamptz default now()
+  )`;
+
+  await sql`create table if not exists ideas (
+    id text primary key,
+    owner_id text not null references users(id) on delete cascade,
+    title text not null,
+    sector text not null,
+    problem text,
+    solution text,
+    market_opportunity text,
+    business_model text,
+    financial_projections text,
+    traction text,
+    location text,
+    media jsonb,
+    status text not null,
+    target_raise text,
+    followers integer default 0,
+    likes integer default 0,
+    created_at timestamptz default now(),
+    unique(title)
+  )`;
+
+  await sql`create table if not exists investor_profiles (
+    id text primary key,
+    user_id text not null references users(id) on delete cascade,
+    ticket_size text,
+    sectors text[],
+    geography text[],
+    risk_appetite text,
+    traction_preference text,
+    watchlist text[],
+    created_at timestamptz default now()
+  )`;
+
+  await sql`create table if not exists feed_entries (
+    id text primary key,
+    user_id text not null references users(id) on delete cascade,
+    message text not null,
+    timestamp timestamptz not null,
+    likes integer default 0,
+    comments integer default 0
+  )`;
+
+  for (const user of users) {
+    await sql`
+      insert into users (
+        id, name, email, role, password, avatar_url, bio, location,
+        social_handles, verification, metrics
+      ) values (
+        ${user.id},
+        ${user.name},
+        ${user.email},
+        ${user.role},
+        ${user.password},
+        ${user.avatarUrl ?? null},
+        ${user.bio ?? null},
+        ${user.location ?? null},
+        ${user.socialHandles ? sql.json(user.socialHandles) : null},
+        ${user.verification ? sql.json(user.verification) : null},
+        ${user.metrics ? sql.json(user.metrics) : null}
+      )
+      on conflict (id) do update set
+        name = excluded.name,
+        email = excluded.email,
+        role = excluded.role,
+        password = excluded.password,
+        avatar_url = excluded.avatar_url,
+        bio = excluded.bio,
+        location = excluded.location,
+        social_handles = excluded.social_handles,
+        verification = excluded.verification,
+        metrics = excluded.metrics
+    `;
+  }
+
+  for (const idea of primaryEntrepreneurIdeas) {
+    await sql`
+      insert into ideas (
+        id, owner_id, title, sector, problem, solution,
+        market_opportunity, business_model, financial_projections,
+        traction, location, media, status, target_raise, followers, likes
+      ) values (
+        ${idea.id},
+        ${idea.ownerId},
+        ${idea.title},
+        ${idea.sector},
+        ${idea.problem},
+        ${idea.solution},
+        ${idea.marketOpportunity},
+        ${idea.businessModel},
+        ${idea.financialProjections},
+        ${idea.traction},
+        ${idea.location},
+        ${idea.media ? sql.json(idea.media) : null},
+        ${idea.status},
+        ${idea.targetRaise ?? null},
+        ${idea.followers},
+        ${idea.likes}
+      )
+      on conflict (id) do update set
+        owner_id = excluded.owner_id,
+        title = excluded.title,
+        sector = excluded.sector,
+        problem = excluded.problem,
+        solution = excluded.solution,
+        market_opportunity = excluded.market_opportunity,
+        business_model = excluded.business_model,
+        financial_projections = excluded.financial_projections,
+        traction = excluded.traction,
+        location = excluded.location,
+        media = excluded.media,
+        status = excluded.status,
+        target_raise = excluded.target_raise,
+        followers = excluded.followers,
+        likes = excluded.likes
+    `;
+  }
+
+  for (const investor of primaryInvestors) {
+    await sql`
+      insert into investor_profiles (
+        id, user_id, ticket_size, sectors, geography, risk_appetite,
+        traction_preference, watchlist
+      ) values (
+        ${investor.id},
+        ${investor.userId},
+        ${investor.ticketSize},
+        ${investor.sectors},
+        ${investor.geography},
+        ${investor.riskAppetite},
+        ${investor.tractionPreference},
+        ${investor.watchlist}
+      )
+      on conflict (id) do update set
+        user_id = excluded.user_id,
+        ticket_size = excluded.ticket_size,
+        sectors = excluded.sectors,
+        geography = excluded.geography,
+        risk_appetite = excluded.risk_appetite,
+        traction_preference = excluded.traction_preference,
+        watchlist = excluded.watchlist
+    `;
+  }
+
+  for (const entry of socialFeed) {
+    await sql`
+      insert into feed_entries (
+        id, user_id, message, timestamp, likes, comments
+      ) values (
+        ${entry.id},
+        ${entry.userId},
+        ${entry.message},
+        ${new Date(entry.timestamp)},
+        ${entry.likes},
+        ${entry.comments}
+      )
+      on conflict (id) do update set
+        user_id = excluded.user_id,
+        message = excluded.message,
+        timestamp = excluded.timestamp,
+        likes = excluded.likes,
+        comments = excluded.comments
+    `;
+  }
+
+  console.log("Database seeded with sample Nafila Shop data.");
+}
+
+main().catch((error) => {
+  console.error("Failed to seed database", error);
+  process.exit(1);
+});

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,0 +1,9 @@
+import { AuthCard } from "@/components/auth-card";
+
+export default function LoginPage() {
+  return (
+    <div className="py-12">
+      <AuthCard type="login" />
+    </div>
+  );
+}

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -1,0 +1,9 @@
+import { AuthCard } from "@/components/auth-card";
+
+export default function RegisterPage() {
+  return (
+    <div className="py-12">
+      <AuthCard type="register" />
+    </div>
+  );
+}

--- a/src/app/(dashboards)/admin/page.tsx
+++ b/src/app/(dashboards)/admin/page.tsx
@@ -1,0 +1,30 @@
+import { DashboardShell } from "@/components/dashboard-shell";
+import { AnalyticsSummary } from "@/components/analytics-summary";
+import { UserDirectory } from "@/components/user-directory";
+import { VerificationBadges } from "@/components/verification-badges";
+
+export default function AdminDashboard() {
+  return (
+    <DashboardShell
+      title="Admin intelligence"
+      description="Monitor onboarding, compliance, and engagement metrics across the Nafila ecosystem."
+      tabs={[
+        { name: "Overview", href: "/admin", active: true },
+        { name: "Users", href: "#users" },
+        { name: "Verification", href: "#verification" },
+        { name: "Reports", href: "#reports" }
+      ]}
+      actions={<button className="rounded-full bg-brand px-4 py-2 text-sm font-semibold text-white shadow-card">Generate report</button>}
+    >
+      <div className="space-y-8">
+        <AnalyticsSummary />
+        <div id="verification">
+          <VerificationBadges />
+        </div>
+        <div id="users">
+          <UserDirectory />
+        </div>
+      </div>
+    </DashboardShell>
+  );
+}

--- a/src/app/(dashboards)/entrepreneur/page.tsx
+++ b/src/app/(dashboards)/entrepreneur/page.tsx
@@ -1,0 +1,35 @@
+import { DashboardShell } from "@/components/dashboard-shell";
+import { IdeaForm } from "@/components/idea-form";
+import { IdeaTable } from "@/components/idea-table";
+
+export default function EntrepreneurDashboard() {
+  return (
+    <DashboardShell
+      title="Entrepreneur workspace"
+      description="Manage startup ideas, upload proof points, and monitor investor engagement."
+      tabs={[
+        { name: "Overview", href: "/entrepreneur", active: true },
+        { name: "Ideas", href: "#ideas" },
+        { name: "Documents", href: "#documents" },
+        { name: "Messages", href: "#messages" }
+      ]}
+      actions={<button className="rounded-full bg-brand px-4 py-2 text-sm font-semibold text-white shadow-card">New pitch</button>}
+    >
+      <section className="grid gap-8 lg:grid-cols-[1.3fr,1fr]">
+        <div id="ideas" className="space-y-6">
+          <h2 className="text-xl font-semibold text-slate-900">Idea portfolio</h2>
+          <IdeaTable />
+        </div>
+        <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-card">
+          <h2 className="text-lg font-semibold text-slate-900">Submit new idea</h2>
+          <p className="text-sm text-slate-500">
+            Capture the problem, solution, traction, and projections in a standardised canvas.
+          </p>
+          <div className="mt-6">
+            <IdeaForm />
+          </div>
+        </div>
+      </section>
+    </DashboardShell>
+  );
+}

--- a/src/app/(dashboards)/investor/page.tsx
+++ b/src/app/(dashboards)/investor/page.tsx
@@ -1,0 +1,35 @@
+import { DashboardShell } from "@/components/dashboard-shell";
+import { InvestorFilters } from "@/components/investor-filters";
+import { IdeaHighlights } from "@/components/idea-highlights";
+import { WatchlistBoard } from "@/components/watchlist-board";
+import { primaryEntrepreneurIdeas } from "@/lib/sampleData";
+
+export default function InvestorDashboard() {
+  return (
+    <DashboardShell
+      title="Investor control room"
+      description="Discover filtered deal flow, manage watchlists, and drive due diligence."
+      tabs={[
+        { name: "Overview", href: "/investor", active: true },
+        { name: "Saved", href: "#watchlist" },
+        { name: "Analytics", href: "#analytics" },
+        { name: "Messages", href: "#messages" }
+      ]}
+      actions={<button className="rounded-full border border-brand/40 px-4 py-2 text-sm font-semibold text-brand hover:border-brand hover:bg-brand/10">Export pipeline</button>}
+    >
+      <div className="space-y-8">
+        <InvestorFilters />
+        <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-card">
+          <h2 className="text-xl font-semibold text-slate-900">Matching opportunities</h2>
+          <p className="text-sm text-slate-500">Pre-filtered results based on your ticket size and preferences.</p>
+          <div className="mt-6">
+            <IdeaHighlights ideas={primaryEntrepreneurIdeas} />
+          </div>
+        </section>
+        <div id="watchlist">
+          <WatchlistBoard />
+        </div>
+      </div>
+    </DashboardShell>
+  );
+}

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,0 +1,64 @@
+"use server";
+
+import { neon } from "@neondatabase/serverless";
+import { revalidatePath } from "next/cache";
+
+interface IdeaRecord {
+  id: string;
+  title: string;
+  owner_id: string;
+  sector: string;
+  status: string;
+  target_raise: string | null;
+}
+
+export async function getIdeasFromDatabase(): Promise<IdeaRecord[]> {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    console.warn("DATABASE_URL is not configured. Returning empty data set.");
+    return [];
+  }
+
+  const sql = neon(connectionString);
+  try {
+    const ideas = await sql<IdeaRecord>`
+      select id, title, owner_id, sector, status, target_raise
+      from ideas
+      order by created_at desc
+      limit 25
+    `;
+    return ideas;
+  } catch (error) {
+    console.error("Failed to query Neon database", error);
+    return [];
+  }
+}
+
+export async function createSampleIdea(data: {
+  title: string;
+  ownerId: string;
+  sector: string;
+  status?: string;
+  targetRaise?: string;
+}) {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error("DATABASE_URL is not configured");
+  }
+
+  const sql = neon(connectionString);
+  const status = data.status ?? "raising";
+
+  await sql`
+    insert into ideas (title, owner_id, sector, status, target_raise)
+    values (${data.title}, ${data.ownerId}, ${data.sector}, ${status}, ${data.targetRaise ?? null})
+    on conflict (title)
+    do update set
+      sector = excluded.sector,
+      status = excluded.status,
+      target_raise = excluded.target_raise
+  `;
+
+  revalidatePath("/entrepreneur");
+  revalidatePath("/investor");
+}

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -1,0 +1,16 @@
+import { SocialFeed } from "@/components/social-feed";
+import { socialFeed } from "@/lib/sampleData";
+
+export default function FeedPage() {
+  return (
+    <div className="space-y-6">
+      <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-card">
+        <h1 className="text-3xl font-bold text-slate-900">Community feed</h1>
+        <p className="mt-2 text-sm text-slate-500">
+          Stay up to date with new pitches, investor updates, and platform announcements.
+        </p>
+      </div>
+      <SocialFeed entries={socialFeed} />
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,19 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  @apply bg-slate-50 text-slate-900 antialiased;
+}
+
+a {
+  @apply text-brand hover:text-brand-dark;
+}
+
+button {
+  @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,85 @@
+import type { Metadata } from "next";
+import { Nunito } from "next/font/google";
+import Link from "next/link";
+import "./globals.css";
+
+const nunito = Nunito({ subsets: ["latin"], variable: "--font-nunito" });
+
+export const metadata: Metadata = {
+  title: "Nafila Shop Platform",
+  description: "A venture collaboration platform for entrepreneurs, investors, and the Nafila community.",
+  metadataBase: new URL("https://nafila.local"),
+  openGraph: {
+    title: "Nafila Shop Platform",
+    description: "Launch, discover, and invest in high-potential ideas.",
+    url: "https://nafila.local",
+    siteName: "Nafila Shop",
+    images: [
+      {
+        url: "https://images.unsplash.com/photo-1556740749-887f6717d7e4",
+        width: 1200,
+        height: 630,
+        alt: "Nafila Shop"
+      }
+    ]
+  }
+};
+
+export default function RootLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en" className={nunito.variable}>
+      <body className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100">
+        <div className="mx-auto max-w-7xl px-4 pb-16 sm:px-6 lg:px-8">
+          <header className="sticky top-0 z-50 bg-white/80 backdrop-blur border-b border-slate-200">
+            <div className="mx-auto max-w-7xl px-4 py-4 sm:px-6 lg:px-8 flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <span className="rounded-full bg-brand/10 p-2 text-brand">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="h-6 w-6">
+                    <path d="M12 2a5 5 0 0 0-5 5v3H6a4 4 0 0 0-4 4v4.25A2.75 2.75 0 0 0 4.75 21h14.5A2.75 2.75 0 0 0 22 18.25V14a4 4 0 0 0-4-4h-1V7a5 5 0 0 0-5-5Zm0 2a3 3 0 0 1 3 3v3H9V7a3 3 0 0 1 3-3Zm-6 8h12a2 2 0 0 1 2 2v4.25a.75.75 0 0 1-.75.75h-14.5a.75.75 0 0 1-.75-.75V14a2 2 0 0 1 2-2Z" />
+                  </svg>
+                </span>
+                <div>
+                  <p className="text-sm font-semibold uppercase tracking-wide text-brand-dark">Nafila Shop</p>
+                  <p className="text-xs text-slate-500">Connecting ideas with capital</p>
+                </div>
+              </div>
+              <nav className="hidden items-center gap-6 text-sm font-medium text-slate-600 sm:flex">
+                <Link href="/" className="hover:text-brand">
+                  Home
+                </Link>
+                <Link href="/entrepreneur" className="hover:text-brand">
+                  Entrepreneur
+                </Link>
+                <Link href="/investor" className="hover:text-brand">
+                  Investor
+                </Link>
+                <Link href="/admin" className="hover:text-brand">
+                  Admin
+                </Link>
+              </nav>
+              <div className="flex items-center gap-3">
+                <Link
+                  href="/login"
+                  className="rounded-full border border-brand/30 px-4 py-2 text-sm text-brand hover:border-brand hover:bg-brand/10"
+                >
+                  Log in
+                </Link>
+                <Link
+                  href="/register"
+                  className="hidden rounded-full bg-brand px-4 py-2 text-sm font-semibold text-white shadow-card transition hover:bg-brand-dark sm:inline-flex"
+                >
+                  Get Started
+                </Link>
+              </div>
+            </div>
+          </header>
+          <main className="pt-10">{children}</main>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,118 @@
+import Link from "next/link";
+import { Lightbulb, Rocket, ShieldCheck, Users2 } from "lucide-react";
+import { primaryEntrepreneurIdeas, primaryInvestors, socialFeed } from "@/lib/sampleData";
+import { IdeaHighlights } from "@/components/idea-highlights";
+import { InvestorSnapshot } from "@/components/investor-snapshot";
+import { SocialFeed } from "@/components/social-feed";
+
+export default function HomePage() {
+  return (
+    <div className="space-y-16">
+      <section className="grid gap-8 rounded-3xl bg-white p-10 shadow-card lg:grid-cols-2">
+        <div className="space-y-6">
+          <div className="inline-flex items-center gap-2 rounded-full border border-brand/30 bg-brand/5 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-brand">
+            Built for Entrepreneurs & Investors
+          </div>
+          <h1 className="text-4xl font-bold tracking-tight text-slate-900 sm:text-5xl">
+            Launch, fund, and grow Africa&apos;s most ambitious businesses.
+          </h1>
+          <p className="text-base text-slate-600">
+            Nafila Shop is a deal-flow operating system combining venture matchmaking, trust-building,
+            and community engagement. Explore validated ideas, meet aligned investors, and build
+            transparent relationships through a single collaborative workspace.
+          </p>
+          <div className="flex flex-wrap gap-3">
+            <Link
+              href="/entrepreneur"
+              className="inline-flex items-center rounded-full bg-brand px-5 py-2.5 text-sm font-semibold text-white shadow-card transition hover:bg-brand-dark"
+            >
+              For entrepreneurs
+            </Link>
+            <Link
+              href="/investor"
+              className="inline-flex items-center rounded-full border border-brand/30 px-5 py-2.5 text-sm font-semibold text-brand transition hover:border-brand hover:bg-brand/10"
+            >
+              For investors
+            </Link>
+          </div>
+          <dl className="grid grid-cols-2 gap-6 text-sm text-slate-500 sm:grid-cols-3">
+            <div>
+              <dt className="font-semibold text-slate-900">Verified founders</dt>
+              <dd>120+</dd>
+            </div>
+            <div>
+              <dt className="font-semibold text-slate-900">Active investors</dt>
+              <dd>65 venture partners</dd>
+            </div>
+            <div>
+              <dt className="font-semibold text-slate-900">Deals tracked</dt>
+              <dd>$7.5M pipeline</dd>
+            </div>
+          </dl>
+        </div>
+        <div className="grid gap-4">
+          <div className="rounded-3xl border border-slate-100 bg-slate-900 p-6 text-white shadow-2xl">
+            <p className="text-sm font-semibold uppercase tracking-wide text-slate-300">Live Watchlist</p>
+            <IdeaHighlights ideas={primaryEntrepreneurIdeas.slice(0, 2)} variant="dark" />
+          </div>
+          <div className="grid gap-4 rounded-3xl border border-slate-200 bg-white p-6">
+            <p className="text-sm font-semibold uppercase tracking-wide text-slate-500">Top investors this week</p>
+            <InvestorSnapshot investors={primaryInvestors.slice(0, 3)} />
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-6 rounded-3xl border border-slate-200 bg-white p-10 shadow-card lg:grid-cols-4">
+        {[{
+          title: "Idea intelligence",
+          description: "Structured canvases for problem, solution, business model, traction, and financials.",
+          icon: Lightbulb
+        },
+        {
+          title: "Deal collaboration",
+          description: "Watchlists, follow, and investor portfolio dashboards bring transparency to deal-making.",
+          icon: Users2
+        },
+        {
+          title: "Launch faster",
+          description: "End-to-end support for pitch videos, data rooms, CAC documents, and traction proofs.",
+          icon: Rocket
+        },
+        {
+          title: "Earn trust",
+          description: "KYC, business verification, and community ratings provide proof of credibility.",
+          icon: ShieldCheck
+        }].map((feature) => (
+          <div key={feature.title} className="space-y-3 rounded-2xl border border-slate-100 p-6">
+            <span className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-brand/10 text-brand">
+              <feature.icon className="h-5 w-5" />
+            </span>
+            <h3 className="text-lg font-semibold text-slate-900">{feature.title}</h3>
+            <p className="text-sm text-slate-600">{feature.description}</p>
+          </div>
+        ))}
+      </section>
+
+      <section className="grid gap-8 lg:grid-cols-[2fr,1fr]">
+        <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-card">
+          <div className="flex items-center justify-between gap-4">
+            <h2 className="text-2xl font-semibold text-slate-900">Fresh ideas to explore</h2>
+            <Link href="/entrepreneur" className="text-sm font-semibold text-brand">
+              View all
+            </Link>
+          </div>
+          <IdeaHighlights ideas={primaryEntrepreneurIdeas} />
+        </div>
+        <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-card">
+          <div className="flex items-center justify-between gap-4">
+            <h2 className="text-2xl font-semibold text-slate-900">Community feed</h2>
+            <Link href="/feed" className="text-sm font-semibold text-brand">
+              Open feed
+            </Link>
+          </div>
+          <SocialFeed entries={socialFeed} />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/components/analytics-summary.tsx
+++ b/src/components/analytics-summary.tsx
@@ -1,0 +1,46 @@
+import { primaryEntrepreneurIdeas, socialFeed, users } from "@/lib/sampleData";
+import { TrendingUp, Users, BriefcaseBusiness, MessageCircle } from "lucide-react";
+
+export function AnalyticsSummary() {
+  const metrics = [
+    {
+      label: "Active entrepreneurs",
+      value: users.filter((user) => user.role === "entrepreneur").length,
+      change: "+18%",
+      icon: Users
+    },
+    {
+      label: "Investors onboarded",
+      value: users.filter((user) => user.role === "investor").length,
+      change: "+12%",
+      icon: BriefcaseBusiness
+    },
+    {
+      label: "Ideas tracked",
+      value: primaryEntrepreneurIdeas.length,
+      change: "+24%",
+      icon: TrendingUp
+    },
+    {
+      label: "Engagement actions",
+      value: socialFeed.reduce((acc, item) => acc + item.likes + item.comments, 0),
+      change: "+32%",
+      icon: MessageCircle
+    }
+  ];
+
+  return (
+    <div className="grid gap-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-card sm:grid-cols-2 lg:grid-cols-4">
+      {metrics.map((metric) => (
+        <div key={metric.label} className="space-y-3 rounded-2xl border border-slate-100 bg-slate-50/80 p-4">
+          <metric.icon className="h-6 w-6 text-brand" />
+          <div>
+            <p className="text-2xl font-bold text-slate-900">{metric.value}</p>
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">{metric.label}</p>
+          </div>
+          <p className="text-xs text-emerald-600">{metric.change} vs last month</p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/auth-card.tsx
+++ b/src/components/auth-card.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+import { z } from "zod";
+import { AtSign, Lock, Phone } from "lucide-react";
+
+const registrationSchema = z.object({
+  name: z.string().min(3, "Full name is required"),
+  email: z.string().email("A valid email is required"),
+  password: z.string().min(8, "Password should be at least 8 characters"),
+  confirmPassword: z.string(),
+  role: z.enum(["entrepreneur", "investor", "general"]),
+  phone: z.string().min(6, "Enter a phone number"),
+  agree: z.boolean().refine((value) => value, "Please accept the terms")
+}).refine((data) => data.password === data.confirmPassword, {
+  message: "Passwords must match",
+  path: ["confirmPassword"]
+});
+
+const loginSchema = z.object({
+  email: z.string().email("A valid email is required"),
+  password: z.string().min(6, "Password is required")
+});
+
+interface AuthCardProps {
+  type: "register" | "login";
+}
+
+export function AuthCard({ type }: AuthCardProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    setIsSubmitting(true);
+    setMessage(null);
+    try {
+      if (type === "register") {
+        const payload = {
+          name: formData.get("name")?.toString() ?? "",
+          email: formData.get("email")?.toString() ?? "",
+          password: formData.get("password")?.toString() ?? "",
+          confirmPassword: formData.get("confirmPassword")?.toString() ?? "",
+          role: (formData.get("role")?.toString() ?? "entrepreneur") as "entrepreneur" | "investor" | "general",
+          phone: formData.get("phone")?.toString() ?? "",
+          agree: formData.get("agree") === "on"
+        };
+        registrationSchema.parse(payload);
+        setMessage("Registration submitted! Integrate with Neon + NextAuth for persistence.");
+      } else {
+        const payload = {
+          email: formData.get("email")?.toString() ?? "",
+          password: formData.get("password")?.toString() ?? ""
+        };
+        loginSchema.parse(payload);
+        setMessage("Login successful! Replace with NextAuth credential provider.");
+      }
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        setMessage(error.errors[0]?.message ?? "Something went wrong");
+      } else {
+        setMessage("An unexpected error occurred");
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-xl rounded-3xl border border-slate-200 bg-white p-8 shadow-card">
+      <div className="space-y-2 text-center">
+        <h1 className="text-2xl font-semibold text-slate-900">
+          {type === "register" ? "Create your Nafila Shop account" : "Welcome back"}
+        </h1>
+        <p className="text-sm text-slate-500">
+          {type === "register"
+            ? "Register as an entrepreneur, investor, or community member to start collaborating."
+            : "Access your personalised deal-flow workspace."}
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="mt-8 space-y-6">
+        {type === "register" && (
+          <div className="grid gap-6 sm:grid-cols-2">
+            <div className="space-y-1">
+              <label className="text-xs font-semibold uppercase tracking-wide text-slate-500" htmlFor="name">
+                Full name
+              </label>
+              <input
+                id="name"
+                name="name"
+                type="text"
+                placeholder="Amina Yusuf"
+                className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 focus:border-brand"
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs font-semibold uppercase tracking-wide text-slate-500" htmlFor="phone">
+                Phone number
+              </label>
+              <div className="relative">
+                <Phone className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+                <input
+                  id="phone"
+                  name="phone"
+                  type="tel"
+                  placeholder="+234 801 234 5678"
+                  className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 pl-10 text-sm text-slate-700 focus:border-brand"
+                />
+              </div>
+            </div>
+            <div className="space-y-1 sm:col-span-2">
+              <label className="text-xs font-semibold uppercase tracking-wide text-slate-500" htmlFor="role">
+                Role
+              </label>
+              <select
+                id="role"
+                name="role"
+                className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 focus:border-brand"
+                defaultValue="entrepreneur"
+              >
+                <option value="entrepreneur">Entrepreneur</option>
+                <option value="investor">Investor</option>
+                <option value="general">Community member</option>
+              </select>
+            </div>
+          </div>
+        )}
+
+        <div className="space-y-1">
+          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500" htmlFor="email">
+            Email address
+          </label>
+          <div className="relative">
+            <AtSign className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+            <input
+              id="email"
+              name="email"
+              type="email"
+              placeholder="you@nafila.africa"
+              className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 pl-10 text-sm text-slate-700 focus:border-brand"
+            />
+          </div>
+        </div>
+
+        <div className="space-y-1">
+          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500" htmlFor="password">
+            Password
+          </label>
+          <div className="relative">
+            <Lock className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+            <input
+              id="password"
+              name="password"
+              type="password"
+              placeholder="********"
+              className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 pl-10 text-sm text-slate-700 focus:border-brand"
+            />
+          </div>
+        </div>
+
+        {type === "register" && (
+          <div className="space-y-1">
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500" htmlFor="confirmPassword">
+              Confirm password
+            </label>
+            <input
+              id="confirmPassword"
+              name="confirmPassword"
+              type="password"
+              placeholder="********"
+              className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 focus:border-brand"
+            />
+          </div>
+        )}
+
+        {type === "register" && (
+          <label className="flex items-center gap-2 text-xs text-slate-500">
+            <input type="checkbox" name="agree" className="h-4 w-4 rounded border-slate-300 text-brand focus:ring-brand" />
+            I agree to the Terms of Service and Privacy Policy.
+          </label>
+        )}
+
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="w-full rounded-full bg-brand px-5 py-3 text-sm font-semibold text-white shadow-card transition hover:bg-brand-dark disabled:cursor-not-allowed disabled:opacity-70"
+        >
+          {isSubmitting ? "Processing..." : type === "register" ? "Create account" : "Log in"}
+        </button>
+      </form>
+
+      {message && (
+        <p className="mt-4 text-center text-sm text-brand-dark">{message}</p>
+      )}
+
+      {type === "login" && (
+        <div className="mt-6 space-y-3">
+          <button className="w-full rounded-full border border-slate-200 bg-white px-5 py-3 text-sm font-semibold text-slate-700 transition hover:border-brand/60">
+            Continue with Google
+          </button>
+          <p className="text-center text-xs text-slate-500">
+            Social login hooks into NextAuth Google provider. Configure OAuth credentials to enable.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/dashboard-shell.tsx
+++ b/src/components/dashboard-shell.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+import { ReactNode } from "react";
+import clsx from "clsx";
+
+interface DashboardShellProps {
+  title: string;
+  description: string;
+  tabs: { name: string; href: string; active?: boolean }[];
+  actions?: ReactNode;
+  children: ReactNode;
+}
+
+export function DashboardShell({ title, description, tabs, actions, children }: DashboardShellProps) {
+  return (
+    <div className="space-y-8">
+      <section className="rounded-3xl border border-slate-200 bg-white p-8 shadow-card">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold text-slate-900">{title}</h1>
+            <p className="mt-1 text-sm text-slate-500">{description}</p>
+          </div>
+          {actions}
+        </div>
+        <nav className="mt-6 flex flex-wrap gap-2 text-sm font-medium">
+          {tabs.map((tab) => (
+            <Link
+              key={tab.name}
+              href={tab.href}
+              className={clsx(
+                "rounded-full px-4 py-2",
+                tab.active ? "bg-brand text-white shadow-card" : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+              )}
+            >
+              {tab.name}
+            </Link>
+          ))}
+        </nav>
+      </section>
+      {children}
+    </div>
+  );
+}

--- a/src/components/idea-form.tsx
+++ b/src/components/idea-form.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useState } from "react";
+import { z } from "zod";
+
+const ideaSchema = z.object({
+  title: z.string().min(3),
+  sector: z.string().min(2),
+  problem: z.string().min(10),
+  solution: z.string().min(10),
+  marketOpportunity: z.string().min(10),
+  businessModel: z.string().min(10),
+  financialProjections: z.string().min(5),
+  traction: z.string().min(5),
+  location: z.string().min(2),
+  pitchVideo: z.string().url().optional().or(z.literal("")),
+  instagram: z.string().url().optional().or(z.literal("")),
+  youtube: z.string().url().optional().or(z.literal("")),
+  targetRaise: z.string().optional(),
+  status: z.enum(["raising", "bootstrapped", "idea", "growing"])
+});
+
+export function IdeaForm() {
+  const [message, setMessage] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(formData: FormData) {
+    setSubmitting(true);
+    setMessage(null);
+    try {
+      const raw = Object.fromEntries(formData.entries());
+      const normalized = {
+        title: String(raw.title ?? ""),
+        sector: String(raw.sector ?? ""),
+        problem: String(raw.problem ?? ""),
+        solution: String(raw.solution ?? ""),
+        marketOpportunity: String(raw.marketOpportunity ?? ""),
+        businessModel: String(raw.businessModel ?? ""),
+        financialProjections: String(raw.financialProjections ?? ""),
+        traction: String(raw.traction ?? ""),
+        location: String(raw.location ?? ""),
+        pitchVideo: String(raw.pitchVideo ?? ""),
+        instagram: String(raw.instagram ?? ""),
+        youtube: String(raw.youtube ?? ""),
+        targetRaise: raw.targetRaise ? String(raw.targetRaise) : undefined,
+        status: (raw.status ?? "raising").toString() as "raising" | "bootstrapped" | "idea" | "growing"
+      };
+      ideaSchema.parse(normalized);
+      setMessage("Idea saved locally. Connect to Neon server actions to persist your data.");
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        setMessage(error.errors[0]?.message ?? "Please review your inputs");
+      } else {
+        setMessage("Unexpected error");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form action={handleSubmit} className="space-y-6">
+      <div className="grid gap-6 sm:grid-cols-2">
+        <div className="space-y-2">
+          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500" htmlFor="title">
+            Idea title
+          </label>
+          <input
+            id="title"
+            name="title"
+            type="text"
+            placeholder="EcoPack Africa"
+            className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 focus:border-brand"
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500" htmlFor="sector">
+            Sector
+          </label>
+          <input
+            id="sector"
+            name="sector"
+            type="text"
+            placeholder="Circular Economy"
+            className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 focus:border-brand"
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500" htmlFor="location">
+            Location
+          </label>
+          <input
+            id="location"
+            name="location"
+            type="text"
+            placeholder="Lagos, Nigeria"
+            className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 focus:border-brand"
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500" htmlFor="targetRaise">
+            Target raise
+          </label>
+          <input
+            id="targetRaise"
+            name="targetRaise"
+            type="text"
+            placeholder="$500k Seed"
+            className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 focus:border-brand"
+          />
+        </div>
+      </div>
+
+      <div className="grid gap-6 sm:grid-cols-2">
+        <FieldArea id="problem" label="Problem statement" placeholder="Describe the pain point you're solving" />
+        <FieldArea id="solution" label="Solution" placeholder="Describe your product or service" />
+        <FieldArea id="marketOpportunity" label="Market opportunity" placeholder="Size and growth of your market" />
+        <FieldArea id="businessModel" label="Business / revenue model" placeholder="How do you make money?" />
+        <FieldArea id="financialProjections" label="Financial projections" placeholder="Forecast revenues, costs, runway" />
+        <FieldArea id="traction" label="Traction / validation" placeholder="Pilots, customers, partnerships" />
+      </div>
+
+      <div className="grid gap-6 sm:grid-cols-3">
+        <div className="space-y-2">
+          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500" htmlFor="pitchVideo">
+            Pitch video link
+          </label>
+          <input
+            id="pitchVideo"
+            name="pitchVideo"
+            type="url"
+            placeholder="https://youtu.be/..."
+            className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 focus:border-brand"
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500" htmlFor="instagram">
+            Instagram
+          </label>
+          <input
+            id="instagram"
+            name="instagram"
+            type="url"
+            placeholder="https://instagram.com/..."
+            className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 focus:border-brand"
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500" htmlFor="youtube">
+            YouTube
+          </label>
+          <input
+            id="youtube"
+            name="youtube"
+            type="url"
+            placeholder="https://youtube.com/..."
+            className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 focus:border-brand"
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <label className="text-xs font-semibold uppercase tracking-wide text-slate-500" htmlFor="status">
+          Status
+        </label>
+        <select
+          id="status"
+          name="status"
+          className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 focus:border-brand"
+          defaultValue="raising"
+        >
+          <option value="raising">Currently raising</option>
+          <option value="growing">Scaling</option>
+          <option value="bootstrapped">Bootstrapped</option>
+          <option value="idea">Idea stage</option>
+        </select>
+      </div>
+
+      <button
+        type="submit"
+        disabled={submitting}
+        className="w-full rounded-full bg-brand px-6 py-3 text-sm font-semibold text-white shadow-card transition hover:bg-brand-dark disabled:cursor-not-allowed disabled:opacity-70"
+      >
+        {submitting ? "Saving..." : "Save idea"}
+      </button>
+
+      {message && <p className="text-center text-sm text-brand-dark">{message}</p>}
+    </form>
+  );
+}
+
+interface FieldAreaProps {
+  id: string;
+  label: string;
+  placeholder: string;
+}
+
+function FieldArea({ id, label, placeholder }: FieldAreaProps) {
+  return (
+    <div className="space-y-2">
+      <label className="text-xs font-semibold uppercase tracking-wide text-slate-500" htmlFor={id}>
+        {label}
+      </label>
+      <textarea
+        id={id}
+        name={id}
+        rows={5}
+        placeholder={placeholder}
+        className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 focus:border-brand"
+      />
+    </div>
+  );
+}

--- a/src/components/idea-highlights.tsx
+++ b/src/components/idea-highlights.tsx
@@ -1,0 +1,99 @@
+import Link from "next/link";
+import { BusinessIdea, users } from "@/lib/sampleData";
+import clsx from "clsx";
+
+interface IdeaHighlightsProps {
+  ideas: BusinessIdea[];
+  variant?: "light" | "dark";
+}
+
+export function IdeaHighlights({ ideas, variant = "light" }: IdeaHighlightsProps) {
+  return (
+    <div className={clsx("space-y-4", variant === "dark" && "text-white")}> 
+      {ideas.map((idea) => {
+        const owner = users.find((user) => user.id === idea.ownerId);
+        return (
+          <article
+            key={idea.id}
+            className={clsx(
+              "rounded-2xl border p-5 transition hover:-translate-y-1 hover:shadow-lg",
+              variant === "dark"
+                ? "border-white/10 bg-white/5"
+                : "border-slate-100 bg-slate-50/60"
+            )}
+          >
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <h3 className="text-lg font-semibold text-inherit">{idea.title}</h3>
+                <p className={clsx("text-sm", variant === "dark" ? "text-white/70" : "text-slate-600")}>{idea.sector}</p>
+              </div>
+              <span className="rounded-full bg-brand/10 px-3 py-1 text-xs font-semibold text-brand">
+                {idea.status.toUpperCase()}
+              </span>
+            </div>
+            <p className={clsx("mt-4 text-sm", variant === "dark" ? "text-white/80" : "text-slate-600")}>{idea.problem}</p>
+            <dl className={clsx("mt-4 grid gap-3 text-xs", variant === "dark" ? "text-white/60" : "text-slate-500")}>
+              <div className="flex items-center justify-between">
+                <dt>Owner</dt>
+                <dd className="font-medium text-inherit">{owner?.name ?? "Unknown"}</dd>
+              </div>
+              <div className="flex items-center justify-between">
+                <dt>Location</dt>
+                <dd className="font-medium text-inherit">{idea.location}</dd>
+              </div>
+              <div className="flex items-center justify-between">
+                <dt>Target raise</dt>
+                <dd className="font-medium text-inherit">{idea.targetRaise ?? "TBA"}</dd>
+              </div>
+            </dl>
+            <div className="mt-4 flex items-center justify-between text-xs font-semibold">
+              <span className="text-brand">{idea.followers} followers</span>
+              <span>{idea.likes} likes</span>
+            </div>
+            <div className="mt-6 flex flex-wrap items-center gap-3 text-xs">
+              {idea.media?.pitchVideo && (
+                <Link
+                  href={idea.media.pitchVideo}
+                  className={clsx(
+                    "inline-flex items-center gap-2 rounded-full px-4 py-2",
+                    variant === "dark"
+                      ? "bg-white/10 text-white hover:bg-white/20"
+                      : "bg-white text-brand hover:bg-brand/10"
+                  )}
+                >
+                  Watch pitch
+                </Link>
+              )}
+              {idea.media?.instagram && (
+                <Link
+                  href={idea.media.instagram}
+                  className={clsx(
+                    "inline-flex items-center gap-2 rounded-full px-4 py-2",
+                    variant === "dark"
+                      ? "bg-white/10 text-white hover:bg-white/20"
+                      : "bg-white text-brand hover:bg-brand/10"
+                  )}
+                >
+                  Instagram
+                </Link>
+              )}
+              {idea.media?.youtube && (
+                <Link
+                  href={idea.media.youtube}
+                  className={clsx(
+                    "inline-flex items-center gap-2 rounded-full px-4 py-2",
+                    variant === "dark"
+                      ? "bg-white/10 text-white hover:bg-white/20"
+                      : "bg-white text-brand hover:bg-brand/10"
+                  )}
+                >
+                  YouTube
+                </Link>
+              )}
+            </div>
+          </article>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/idea-table.tsx
+++ b/src/components/idea-table.tsx
@@ -1,0 +1,39 @@
+import { BusinessIdea, primaryEntrepreneurIdeas } from "@/lib/sampleData";
+
+interface IdeaTableProps {
+  ideas?: BusinessIdea[];
+}
+
+export function IdeaTable({ ideas = primaryEntrepreneurIdeas }: IdeaTableProps) {
+  return (
+    <div className="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-card">
+      <table className="min-w-full divide-y divide-slate-200">
+        <thead className="bg-slate-50">
+          <tr className="text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+            <th className="px-6 py-3">Idea</th>
+            <th className="px-6 py-3">Sector</th>
+            <th className="px-6 py-3">Stage</th>
+            <th className="px-6 py-3">Target raise</th>
+            <th className="px-6 py-3">Followers</th>
+            <th className="px-6 py-3">Likes</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100 text-sm text-slate-600">
+          {ideas.map((idea) => (
+            <tr key={idea.id} className="hover:bg-slate-50">
+              <td className="px-6 py-4">
+                <div className="font-semibold text-slate-900">{idea.title}</div>
+                <div className="text-xs text-slate-500">{idea.location}</div>
+              </td>
+              <td className="px-6 py-4">{idea.sector}</td>
+              <td className="px-6 py-4 capitalize">{idea.status}</td>
+              <td className="px-6 py-4">{idea.targetRaise ?? "TBA"}</td>
+              <td className="px-6 py-4">{idea.followers}</td>
+              <td className="px-6 py-4">{idea.likes}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/investor-filters.tsx
+++ b/src/components/investor-filters.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { primaryEntrepreneurIdeas } from "@/lib/sampleData";
+
+interface FilterOption {
+  label: string;
+  value: string;
+}
+
+interface InvestorFiltersProps {
+  onFilterChange?: (filters: Record<string, string | string[]>) => void;
+}
+
+export function InvestorFilters({ onFilterChange }: InvestorFiltersProps) {
+  const sectors = useMemo<FilterOption[]>(() => {
+    const unique = new Set(primaryEntrepreneurIdeas.map((idea) => idea.sector));
+    return Array.from(unique).map((sector) => ({ label: sector, value: sector }));
+  }, []);
+
+  const locations = useMemo<FilterOption[]>(() => {
+    const unique = new Set(primaryEntrepreneurIdeas.map((idea) => idea.location));
+    return Array.from(unique).map((location) => ({ label: location, value: location }));
+  }, []);
+
+  const [selectedSector, setSelectedSector] = useState<string>("all");
+  const [selectedLocation, setSelectedLocation] = useState<string>("all");
+  const [riskProfile, setRiskProfile] = useState<string>("medium");
+
+  function broadcast(filters: Record<string, string | string[]>) {
+    onFilterChange?.(filters);
+  }
+
+  function handleSectorChange(value: string) {
+    setSelectedSector(value);
+    broadcast({ sector: value, location: selectedLocation, risk: riskProfile });
+  }
+
+  function handleLocationChange(value: string) {
+    setSelectedLocation(value);
+    broadcast({ sector: selectedSector, location: value, risk: riskProfile });
+  }
+
+  function handleRiskChange(value: string) {
+    setRiskProfile(value);
+    broadcast({ sector: selectedSector, location: selectedLocation, risk: value });
+  }
+
+  return (
+    <div className="grid gap-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-card sm:grid-cols-3">
+      <div className="space-y-2">
+        <label className="text-xs font-semibold uppercase tracking-wide text-slate-500" htmlFor="sector">
+          Sector
+        </label>
+        <select
+          id="sector"
+          className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 focus:border-brand"
+          value={selectedSector}
+          onChange={(event) => handleSectorChange(event.target.value)}
+        >
+          <option value="all">All sectors</option>
+          {sectors.map((sector) => (
+            <option key={sector.value} value={sector.value}>
+              {sector.label}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="space-y-2">
+        <label className="text-xs font-semibold uppercase tracking-wide text-slate-500" htmlFor="location">
+          Location
+        </label>
+        <select
+          id="location"
+          className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 focus:border-brand"
+          value={selectedLocation}
+          onChange={(event) => handleLocationChange(event.target.value)}
+        >
+          <option value="all">All locations</option>
+          {locations.map((location) => (
+            <option key={location.value} value={location.value}>
+              {location.label}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="space-y-2">
+        <label className="text-xs font-semibold uppercase tracking-wide text-slate-500" htmlFor="risk">
+          Risk appetite
+        </label>
+        <select
+          id="risk"
+          className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 focus:border-brand"
+          value={riskProfile}
+          onChange={(event) => handleRiskChange(event.target.value)}
+        >
+          <option value="low">Low</option>
+          <option value="medium">Medium</option>
+          <option value="high">High</option>
+        </select>
+      </div>
+    </div>
+  );
+}

--- a/src/components/investor-snapshot.tsx
+++ b/src/components/investor-snapshot.tsx
@@ -1,0 +1,43 @@
+import { InvestorProfile, users } from "@/lib/sampleData";
+
+interface InvestorSnapshotProps {
+  investors: InvestorProfile[];
+}
+
+export function InvestorSnapshot({ investors }: InvestorSnapshotProps) {
+  return (
+    <div className="space-y-4">
+      {investors.map((investor) => {
+        const user = users.find((candidate) => candidate.id === investor.userId);
+        const avatar = user?.avatarUrl ?? `https://avatar.vercel.sh/${encodeURIComponent(user?.name ?? "investor")}`;
+        return (
+          <div key={investor.id} className="flex items-start gap-4 rounded-2xl border border-slate-100 bg-slate-50/80 p-4">
+            <img
+              src={avatar}
+              alt={user?.name}
+              className="h-12 w-12 rounded-full border border-white object-cover shadow"
+            />
+            <div className="space-y-3">
+              <div>
+                <p className="text-sm font-semibold text-slate-900">{user?.name ?? "Investor"}</p>
+                <p className="text-xs text-slate-500">Ticket size: {investor.ticketSize}</p>
+              </div>
+              <div className="grid gap-2 text-xs text-slate-600">
+                <p>
+                  <span className="font-semibold text-slate-900">Sectors:</span> {investor.sectors.join(", ")}
+                </p>
+                <p>
+                  <span className="font-semibold text-slate-900">Geographies:</span> {investor.geography.join(", ")}
+                </p>
+                <p>
+                  <span className="font-semibold text-slate-900">Risk:</span> {investor.riskAppetite.toUpperCase()}
+                </p>
+                <p className="text-slate-500">{investor.tractionPreference}</p>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/social-feed.tsx
+++ b/src/components/social-feed.tsx
@@ -1,0 +1,40 @@
+import { FeedEntry, users } from "@/lib/sampleData";
+import { formatDistanceToNow } from "date-fns";
+
+interface SocialFeedProps {
+  entries: FeedEntry[];
+}
+
+export function SocialFeed({ entries }: SocialFeedProps) {
+  return (
+    <div className="space-y-4">
+      {entries.map((entry) => {
+        const user = users.find((candidate) => candidate.id === entry.userId);
+        const avatar = user?.avatarUrl ?? `https://avatar.vercel.sh/${encodeURIComponent(user?.name ?? "user")}`;
+        return (
+          <article key={entry.id} className="rounded-2xl border border-slate-100 bg-slate-50/60 p-4">
+            <div className="flex items-start gap-3">
+              <img
+                src={avatar}
+                alt={user?.name}
+                className="h-10 w-10 rounded-full object-cover"
+              />
+              <div className="space-y-2">
+                <div className="flex items-center gap-2 text-xs text-slate-500">
+                  <span className="font-semibold text-slate-900">{user?.name ?? "Community member"}</span>
+                  <span>•</span>
+                  <span>{formatDistanceToNow(new Date(entry.timestamp), { addSuffix: true })}</span>
+                </div>
+                <p className="text-sm text-slate-700">{entry.message}</p>
+                <div className="flex items-center gap-4 text-xs text-slate-500">
+                  <span>{entry.likes} likes</span>
+                  <span>{entry.comments} comments</span>
+                </div>
+              </div>
+            </div>
+          </article>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/user-directory.tsx
+++ b/src/components/user-directory.tsx
@@ -1,0 +1,38 @@
+import { users } from "@/lib/sampleData";
+
+export function UserDirectory() {
+  return (
+    <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-card">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-900">Community directory</h2>
+          <p className="text-sm text-slate-500">Search, follow, and connect with founders and investors.</p>
+        </div>
+      </div>
+      <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {users.map((user) => {
+          const avatar = user.avatarUrl ?? `https://avatar.vercel.sh/${encodeURIComponent(user.name ?? "user")}`;
+          return (
+          <div key={user.id} className="space-y-3 rounded-2xl border border-slate-100 bg-slate-50/80 p-4">
+            <div className="flex items-center gap-3">
+              <img src={avatar} alt={user.name} className="h-12 w-12 rounded-full object-cover" />
+              <div>
+                <p className="text-sm font-semibold text-slate-900">{user.name}</p>
+                <p className="text-xs text-slate-500 capitalize">{user.role}</p>
+              </div>
+            </div>
+            <p className="text-xs text-slate-600">{user.bio}</p>
+            <div className="flex items-center justify-between text-xs text-slate-500">
+              <span>{user.metrics?.followers ?? 0} followers</span>
+              <span>{user.metrics?.likes ?? 0} likes</span>
+            </div>
+            <button className="w-full rounded-full border border-brand/40 bg-white px-4 py-2 text-xs font-semibold text-brand transition hover:border-brand hover:bg-brand/10">
+              Follow
+            </button>
+          </div>
+        );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/verification-badges.tsx
+++ b/src/components/verification-badges.tsx
@@ -1,0 +1,37 @@
+import { users } from "@/lib/sampleData";
+
+export function VerificationBadges() {
+  return (
+    <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-card">
+      <h2 className="text-lg font-semibold text-slate-900">Verification centre</h2>
+      <p className="mt-2 text-sm text-slate-500">
+        Upload compliance documents and monitor KYC progress across stakeholders.
+      </p>
+      <div className="mt-6 grid gap-4">
+        {users.map((user) => {
+          const avatar = user.avatarUrl ?? `https://avatar.vercel.sh/${encodeURIComponent(user.name ?? "user")}`;
+          return (
+            <div
+              key={user.id}
+              className="flex items-center justify-between rounded-2xl border border-slate-100 bg-slate-50/80 p-4"
+            >
+              <div className="flex items-center gap-3">
+                <img src={avatar} alt={user.name} className="h-10 w-10 rounded-full object-cover" />
+                <div>
+                  <p className="text-sm font-semibold text-slate-900">{user.name}</p>
+                  <p className="text-xs text-slate-500 capitalize">{user.role}</p>
+                </div>
+              </div>
+              <div className="text-right text-xs">
+                <p className="font-semibold text-brand">{user.verification?.kycStatus ?? "pending"}</p>
+                {user.verification?.businessDocs && (
+                  <p className="text-slate-500">{user.verification.businessDocs.length} documents uploaded</p>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/watchlist-board.tsx
+++ b/src/components/watchlist-board.tsx
@@ -1,0 +1,32 @@
+import { primaryEntrepreneurIdeas, primaryInvestors } from "@/lib/sampleData";
+
+export function WatchlistBoard() {
+  const watchlistIds = new Set(primaryInvestors.flatMap((investor) => investor.watchlist));
+  const watchlistIdeas = primaryEntrepreneurIdeas.filter((idea) => watchlistIds.has(idea.id));
+
+  return (
+    <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-card">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-900">Investor watchlist</h2>
+          <p className="text-sm text-slate-500">Monitor traction and follow-ups for saved startups.</p>
+        </div>
+      </div>
+      <div className="mt-6 grid gap-4 sm:grid-cols-2">
+        {watchlistIdeas.map((idea) => (
+          <div key={idea.id} className="rounded-2xl border border-slate-100 bg-slate-50/80 p-4">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold text-slate-900">{idea.title}</h3>
+              <span className="text-xs font-semibold uppercase text-brand">{idea.status}</span>
+            </div>
+            <p className="mt-2 text-xs text-slate-500">{idea.problem}</p>
+            <div className="mt-3 flex items-center justify-between text-xs text-slate-500">
+              <span>{idea.followers} followers</span>
+              <span>{idea.likes} likes</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/sampleData.ts
+++ b/src/lib/sampleData.ts
@@ -1,0 +1,256 @@
+export type UserRole = "entrepreneur" | "investor" | "admin" | "general";
+
+export interface UserAccount {
+  id: string;
+  name: string;
+  email: string;
+  role: UserRole;
+  password: string;
+  avatarUrl?: string;
+  bio?: string;
+  location?: string;
+  socialHandles?: {
+    linkedin?: string;
+    twitter?: string;
+    instagram?: string;
+    youtube?: string;
+    website?: string;
+  };
+  verification?: {
+    kycStatus: "pending" | "verified" | "rejected";
+    businessDocs?: string[];
+  };
+  metrics?: {
+    followers: number;
+    likes: number;
+    dealsClosed?: number;
+  };
+}
+
+export interface BusinessIdea {
+  id: string;
+  ownerId: string;
+  title: string;
+  sector: string;
+  problem: string;
+  solution: string;
+  marketOpportunity: string;
+  businessModel: string;
+  financialProjections: string;
+  traction: string;
+  location: string;
+  media?: {
+    pitchVideo?: string;
+    deckUrl?: string;
+    instagram?: string;
+    twitter?: string;
+    youtube?: string;
+  };
+  status: "raising" | "bootstrapped" | "idea" | "growing";
+  targetRaise?: string;
+  followers: number;
+  likes: number;
+}
+
+export interface InvestorProfile {
+  id: string;
+  userId: string;
+  ticketSize: string;
+  sectors: string[];
+  geography: string[];
+  riskAppetite: "low" | "medium" | "high";
+  tractionPreference: string;
+  watchlist: string[];
+}
+
+export interface FeedEntry {
+  id: string;
+  userId: string;
+  message: string;
+  timestamp: string;
+  likes: number;
+  comments: number;
+}
+
+export const users: UserAccount[] = [
+  {
+    id: "user_entrepreneur_1",
+    name: "Amina Yusuf",
+    email: "amina@nafila.africa",
+    role: "entrepreneur",
+    password: "Nafila@2024",
+    avatarUrl: "https://i.pravatar.cc/150?img=47",
+    bio: "Founder of EcoPack, transforming agricultural waste into biodegradable packaging.",
+    location: "Lagos, Nigeria",
+    socialHandles: {
+      linkedin: "https://linkedin.com/in/aminayusuf",
+      instagram: "https://instagram.com/ecopack.africa",
+      youtube: "https://youtube.com/@ecopack"
+    },
+    verification: {
+      kycStatus: "verified",
+      businessDocs: ["CAC-REG-10293", "TIN-445620"]
+    },
+    metrics: {
+      followers: 420,
+      likes: 1365,
+      dealsClosed: 2
+    }
+  },
+  {
+    id: "user_investor_1",
+    name: "Kwame Mensah",
+    email: "kwame.mensah@panthera.vc",
+    role: "investor",
+    password: "InvestSmart!2024",
+    avatarUrl: "https://i.pravatar.cc/150?img=12",
+    bio: "Partner at Panthera Capital investing in sustainable supply-chain infrastructure.",
+    location: "Accra, Ghana",
+    socialHandles: {
+      linkedin: "https://linkedin.com/in/kwamemensah",
+      twitter: "https://twitter.com/kwameVC"
+    },
+    verification: {
+      kycStatus: "verified",
+      businessDocs: ["SEC-INV-9043"]
+    },
+    metrics: {
+      followers: 880,
+      likes: 2390,
+      dealsClosed: 14
+    }
+  },
+  {
+    id: "user_admin_1",
+    name: "Nafila Admin",
+    email: "admin@nafila.africa",
+    role: "admin",
+    password: "AdminSecure#2024",
+    avatarUrl: "https://i.pravatar.cc/150?img=3",
+    bio: "Operational excellence lead managing onboarding, moderation, and analytics.",
+    location: "Remote",
+    verification: {
+      kycStatus: "verified"
+    },
+    metrics: {
+      followers: 240,
+      likes: 640
+    }
+  }
+];
+
+export const primaryEntrepreneurIdeas: BusinessIdea[] = [
+  {
+    id: "idea_1",
+    ownerId: "user_entrepreneur_1",
+    title: "EcoPack Africa",
+    sector: "Circular Economy",
+    problem: "Over 8M tons of plastic waste produced annually in West Africa with limited recycling.",
+    solution: "Biodegradable packaging made from cassava peels sourced from smallholder farmers.",
+    marketOpportunity: "Food & beverage brands seeking ESG compliant packaging in ECOWAS.",
+    businessModel: "B2B supply contracts with FMCGs and marketplaces.",
+    financialProjections: "$1.5M ARR forecast by FY26 with 45% gross margin.",
+    traction: "Signed MOUs with 3 FMCGs and delivered 50 pilot shipments.",
+    location: "Lagos, Nigeria",
+    media: {
+      pitchVideo: "https://youtu.be/ecoPackPitch",
+      instagram: "https://instagram.com/ecopack.africa",
+      youtube: "https://youtube.com/@ecopack"
+    },
+    status: "raising",
+    targetRaise: "$750k Seed",
+    followers: 260,
+    likes: 940
+  },
+  {
+    id: "idea_2",
+    ownerId: "user_entrepreneur_1",
+    title: "SafiCold Logistics",
+    sector: "AgriTech",
+    problem: "Post-harvest losses cost East African farmers $4B annually due to inadequate cold chain.",
+    solution: "Solar-powered cold storage pods deployed through cooperatives.",
+    marketOpportunity: "1.4M smallholder farmers within East African Grain Council.",
+    businessModel: "Revenue share model with cooperatives and B2B contracts with exporters.",
+    financialProjections: "$3.2M ARR by FY27 with 35% EBITDA margin.",
+    traction: "120 pilot farmers onboarded with 28% waste reduction.",
+    location: "Nairobi, Kenya",
+    media: {
+      pitchVideo: "https://youtu.be/saficoldPitch",
+      instagram: "https://instagram.com/saficold"
+    },
+    status: "growing",
+    targetRaise: "$1.2M Series A",
+    followers: 410,
+    likes: 1280
+  },
+  {
+    id: "idea_3",
+    ownerId: "user_entrepreneur_1",
+    title: "BluePulse Health",
+    sector: "HealthTech",
+    problem: "Clinics lack remote monitoring for chronic patients leading to avoidable readmissions.",
+    solution: "AI-enabled vitals monitoring with clinician dashboards and patient wearables.",
+    marketOpportunity: "175k chronic patients served by regional hospitals in Ghana.",
+    businessModel: "Subscription-based SaaS for hospitals plus device rentals.",
+    financialProjections: "$980k ARR within 24 months, break-even at 18 months.",
+    traction: "3 hospitals in pilot with 1,200 patients enrolled.",
+    location: "Accra, Ghana",
+    media: {
+      pitchVideo: "https://youtu.be/bluepulsePitch"
+    },
+    status: "raising",
+    targetRaise: "$500k Seed",
+    followers: 330,
+    likes: 1050
+  }
+];
+
+export const primaryInvestors: InvestorProfile[] = [
+  {
+    id: "investor_profile_1",
+    userId: "user_investor_1",
+    ticketSize: "$100k - $500k",
+    sectors: ["Circular Economy", "AgriTech", "Climate"],
+    geography: ["West Africa", "East Africa"],
+    riskAppetite: "medium",
+    tractionPreference: "Post-revenue with demonstrable supply chain partners.",
+    watchlist: ["idea_1", "idea_2"]
+  },
+  {
+    id: "investor_profile_2",
+    userId: "user_investor_1",
+    ticketSize: "$500k - $1.5M",
+    sectors: ["HealthTech", "FinTech"],
+    geography: ["West Africa"],
+    riskAppetite: "medium",
+    tractionPreference: "Clinics with >500 patients or ARR > $40k.",
+    watchlist: ["idea_3"]
+  }
+];
+
+export const socialFeed: FeedEntry[] = [
+  {
+    id: "feed_1",
+    userId: "user_entrepreneur_1",
+    message: "EcoPack just shipped our 10,000th compostable mailer with zero delivery defects!",
+    timestamp: "2024-05-18T08:30:00Z",
+    likes: 124,
+    comments: 16
+  },
+  {
+    id: "feed_2",
+    userId: "user_investor_1",
+    message: "Reviewing sustainable supply chain pitches this week. Drop your decks!",
+    timestamp: "2024-05-19T11:00:00Z",
+    likes: 212,
+    comments: 45
+  },
+  {
+    id: "feed_3",
+    userId: "user_admin_1",
+    message: "New compliance update: upload CAC certificates and national IDs before June 30 for verification badges.",
+    timestamp: "2024-05-20T17:45:00Z",
+    likes: 86,
+    comments: 9
+  }
+];

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,22 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./src/**/*.{js,ts,jsx,tsx,mdx}"],
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          DEFAULT: "#0f766e",
+          dark: "#0d504b",
+          light: "#14b8a6"
+        }
+      },
+      boxShadow: {
+        card: "0 20px 25px -5px rgba(15, 118, 110, 0.1), 0 10px 10px -5px rgba(15, 118, 110, 0.04)"
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "types": ["@types/node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a Neon-powered TypeScript seeding script that creates core tables and loads the provided sample users, ideas, and social data
- expose an `npm run seed` helper along with dotenv/ts-node dependencies for running the seeder
- document the seeding step in the README so sample credentials are easy to load

## Testing
- not run (dependencies unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e23349bc2c8330b709d0de82a7f950